### PR TITLE
 fix error in index page of api tester

### DIFF
--- a/apitester/obp/api.py
+++ b/apitester/obp/api.py
@@ -54,9 +54,9 @@ class API(object):
         time_start = time.time()
         try:
             if payload:
-                response = session.request(method, url, json=payload)
+                response = session.request(method, url, json=payload, verify=False)
             else:
-                response = session.request(method, url)
+                response = session.request(method, url, verify=False)
         except ConnectionError as err:
             raise APIError(err)
         time_end = time.time()

--- a/apitester/obp/oauth.py
+++ b/apitester/obp/oauth.py
@@ -35,7 +35,7 @@ class OAuthAuthenticator(Authenticator):
         )
         try:
             url = settings.API_HOST + settings.OAUTH_TOKEN_PATH
-            response = session.fetch_request_token(url)
+            response = session.fetch_request_token(url, verify=False)
         except (ValueError, TokenRequestDenied, ConnectionError) as err:
             raise AuthenticatorError(err)
         else:

--- a/apitester/runtests/views.py
+++ b/apitester/runtests/views.py
@@ -33,15 +33,6 @@ URLPATH_REPLACABLES = [
     'FROM_CURRENCY_CODE', 'TO_CURRENCY_CODE',
 ]
 
-DEFAULT_VALUES = [
-    '3.0.0','robert.xuk.x@example.com','robert.xuk.x@example.com','1',
-    'psd201-bank-x--uk','9cf8-1234','24a2-24242','6056-M35',
-    '05237266-b334-4704-a087-5b460a2ecf04',
-    '05237266-b334-4704-a087-5b460a2ecf04','1','b52a3465-d484-4b9a-97da-308188af7c6a','British Gas',
-    'bank-x281290865','1','1',
-    'GBP','GBP',
-]
-
 class IndexView(LoginRequiredMixin, TemplateView):
     """Index view for runtests"""
     template_name = "runtests/index.html"

--- a/apitester/runtests/views.py
+++ b/apitester/runtests/views.py
@@ -5,6 +5,7 @@ Views of runtests app
 
 import json
 import urllib
+import re
 
 from django.conf import settings
 from django.contrib import messages
@@ -32,6 +33,14 @@ URLPATH_REPLACABLES = [
     'FROM_CURRENCY_CODE', 'TO_CURRENCY_CODE',
 ]
 
+DEFAULT_VALUES = [
+    '3.0.0','robert.xuk.x@example.com','robert.xuk.x@example.com','1',
+    'psd201-bank-x--uk','9cf8-1234','24a2-24242','6056-M35',
+    '05237266-b334-4704-a087-5b460a2ecf04',
+    '05237266-b334-4704-a087-5b460a2ecf04','1','b52a3465-d484-4b9a-97da-308188af7c6a','British Gas',
+    'bank-x281290865','1','1',
+    'GBP','GBP',
+]
 
 class IndexView(LoginRequiredMixin, TemplateView):
     """Index view for runtests"""
@@ -126,6 +135,10 @@ class IndexView(LoginRequiredMixin, TemplateView):
 
         if 'selected' in testconfigs and testconfigs['selected']:
             api_version = testconfigs['selected'].api_version
+
+            if re.match("^[1-3]\.[0-9]\.[0-9]$", api_version) is None:
+                api_version = settings.API_VERSION
+
             try:
                 swagger = api.get_swagger(api_version)
             except APIError as err:

--- a/apitester/runtests/views.py
+++ b/apitester/runtests/views.py
@@ -21,7 +21,6 @@ from obp.api import API, APIError
 from .forms import TestConfigurationForm
 from .models import TestConfiguration,ProfileOperation
 
-
 # TODO: These have to map to attributes of models.TestConfiguration
 URLPATH_REPLACABLES = [
     'API_VERSION',


### PR DESCRIPTION
An error occurs while getting swagger with a wrong api version that costumers type. 
Check if api version matches version pattern, if not, assign it as a default value.